### PR TITLE
Update 00_introduction.md

### DIFF
--- a/docs/user_manual/quick_starts/en-US/chapter_01_overview_of_the_oceanbase_database/00_introduction.md
+++ b/docs/user_manual/quick_starts/en-US/chapter_01_overview_of_the_oceanbase_database/00_introduction.md
@@ -21,7 +21,6 @@ You can contact us in the following ways:
 
 * GitHub page for reporting issues of OceanBase Database Community Edition: [https://github.com/oceanbase/oceanbase/issues](https://github.com/oceanbase/oceanbase/issues) 
 
-* DingTalk group ID: 33254054
 
 > **Note**
 >


### PR DESCRIPTION
Dingtalk is not a commonly used office software overseas. It is advisable to consider Teams or other community methods. Before making a decision, it is recommended to remove it to avoid affecting the user experience. Even if it is determined to continue using DingTalk groups later, it is also necessary to consider creating separate groups or providing the DingTalk download channel at the same time.

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
